### PR TITLE
Fix CRC32 signed integer wrap-around

### DIFF
--- a/index_to_xml.py
+++ b/index_to_xml.py
@@ -6,12 +6,13 @@ import os
 import tempfile
 
 def crc32_to_hex( crc ):
-	ulong = long()
-	if( crc < 0 ):
-		ulong = crc+2**31
-	else:
-		ulong = crc
-	return hex(ulong)[2:].upper()
+	ulong = long(crc)
+	if( ulong < 0 ):
+		ulong = ulong + 2**32
+	hex_ulong = hex(ulong)[2:].upper()
+	if hex_ulong[-1] == "L":
+		return hex_ulong[:-1]
+	return hex_ulong
 
 
 class XmlWriter:


### PR DESCRIPTION
This fixes CRC32 calculation for Python versions less than 3.0, where crc32() returns integers in the range [-2**31, 2**31-1]
